### PR TITLE
Fix missing port in URL construction

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -3,9 +3,11 @@ const tabsData = {};
 chrome.runtime.onMessage.addListener((message, sender) => {
   if (message.type === 'openDataPage') {
     const jiraOriginalUrl = sender.tab.url;
-    const { hostname } = new URL(jiraOriginalUrl);
+    const urlObj = new URL(jiraOriginalUrl);
+    const { hostname } = urlObj;
+    const { port } = urlObj;
     const { rapidView } = message;
-    const pluginPageURL = `index.html?host=${hostname}&rapidView=${rapidView}`;
+    const pluginPageURL = `index.html?host=${hostname}${port ? `&port=${port}` : ''}&rapidView=${rapidView}`;
 
     chrome.tabs.create({ url: pluginPageURL }, (tab) => {
       tabsData[tab.id] = { jiraOriginalUrl };

--- a/src/contexts/JiraDataContext.jsx
+++ b/src/contexts/JiraDataContext.jsx
@@ -22,7 +22,8 @@ export function JiraDataProvider({ children }) {
 
   const query = useQuery();
   const hostname = query.get('host');
-  const baseUrl = `https://${hostname}`;
+  const port = query.get('port');
+  const baseUrl = port ? `https://${hostname}:${port}` : `https://${hostname}`;
   const rapidViewParam = query.get('rapidView');
 
   useEffect(() => {


### PR DESCRIPTION
Ensure the URL includes the port when specified in plugin activation. 
This fixes an issue where connections to jira server running on non-standard ports would fail.
